### PR TITLE
send results to participants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+package-lock.json
 *.js~
 *.json~
 *.html~

--- a/resources/client.html
+++ b/resources/client.html
@@ -57,7 +57,6 @@ function discoverQuizzes() {
 		var request = {
 			"code" : code
 		};
-		console.log(request);
 		socket.emit("DiscoveryRequest", request);
 	}
 }
@@ -115,13 +114,13 @@ socket.on('QuizQuestion', function(question) {
 });
 
 // show correct answer to question
-socket.on("RevealCorrect", function() {
-	qr.reveal();
+socket.on("RevealCorrect", function(answers) {
+	qr.reveal(answers);
 });
 
 socket.on('ping', function(data){
 	socket.emit('pong', data);
-});    
+});
 
 
 </script>

--- a/resources/quizmaster.html
+++ b/resources/quizmaster.html
@@ -60,10 +60,10 @@ function handleFileSelect(evt) {
 
 	// Closure to capture the file information.
 	reader.onload = (function (theFile) {
-        	return function (e) { 
+			return function (e) { 
 				qh = new QuizHolder(JSON.parse(e.target.result));
 				sendQuestion();
-        	};
+			};
 	})(f);
 
 	// Read in JSON as a data URL.
@@ -104,7 +104,7 @@ $("#prev").click(function() {
 	qh.prev();
 	sendQuestion();
 });
-     
+
 $("#next").click(function() {
 	qh.next();
 	sendQuestion();
@@ -115,12 +115,16 @@ $("#reveal").click(function() {
 		return;
 	}
 
+	// remove voter information now that it is not needed any more
+	var answers_masked = Object.keys(answers).map(key=>answers[key]);
+
 	var revealMsg = {
-		"quizinstance" : quizinstance
+		"quizinstance" : quizinstance,
+		"answers": answers_masked
 	};
 
 	socket.emit("RevealCorrect", revealMsg);
-	qr.reveal(answers);
+	qr.reveal(answers_masked);
 	updateUI();
 });
 

--- a/server.js
+++ b/server.js
@@ -121,7 +121,7 @@ io.on('connection', function(socket){
 	// forward correct option to clients
 	socket.on("RevealCorrect", function(revealMsg) {
 		if(!revealMsg || !revealMsg.quizinstance) return;
-		io.in("clients." + revealMsg.quizinstance).emit("RevealCorrect");
+		io.in("clients." + revealMsg.quizinstance).emit("RevealCorrect", revealMsg.answers);
 	});
 
 

--- a/static/shared.js
+++ b/static/shared.js
@@ -41,10 +41,10 @@ QuizRenderer = function(topElementSelector) {
 				canvas.attr("width", img.width).attr("height", img.height);
 				var ctx = canvas[0].getContext("2d");
 				ctx.drawImage(img,0,0);
-			};			
+			};
 			img.src = question.image;
 
-			if(clickcallback) {
+			if(clickcallback && question.type == 1) {
 				canvas.click(function(evt) {
 					if(revealed) return;
 
@@ -52,7 +52,6 @@ QuizRenderer = function(topElementSelector) {
 					var y = evt.pageY - canvas[0].offsetTop;
 
 					var click = {
-						type: "imageclick",
 						x: x,
 						y: y
 					};
@@ -135,46 +134,33 @@ QuizRenderer = function(topElementSelector) {
 	this.reveal = function(votes) {
 		revealed = true;
 
-		// determine votes per option
-		for(var i = 0; i < 999; ++i) {
-			var option = $("#option" + i);
-			if(!option.length) {
-				break;
+		if(this.question.type==1){
+			// draw image markings
+			for(var click of votes) {
+				that.markImagePosition(click.x, click.y);
 			}
+		}else{
+			// determine votes per option
+			for(var i = 0; i < 999; ++i) {
+				var option = $("#option" + i);
+				if(!option.length) {
+					break;
+				}
 
-			var originalidx = option.data("originalindex");
-			var correctOption = originalidx == 0 || this.question.type == 2;
+				var originalidx = option.data("originalindex");
+				var correctOption = originalidx == 0 || this.question.type == 2;
 
-			option.toggleClass("correct", correctOption);
-			option.toggleClass("incorrect", !correctOption);
+				option.toggleClass("correct", correctOption);
+				option.toggleClass("incorrect", !correctOption);
 
-			if(votes) {
 				var optioncount = $("#optioncount" + i);
 				var count = 0;
-				for(var key in votes) {
-					var click = votes[key];
-					if(click.type != "optionclick") {
-						continue;
-					}
+				for(var click of votes) {
 					if(originalidx === click.clickedoption) {
 						count++;
 					}
 				}
 				optioncount.text(count + "");
-			}
-
-		}
-
-
-		// draw image markings
-		if(votes) {
-			for(var key in votes) {
-				var click = votes[key];
-				if(click.type != "imageclick") {
-					continue;
-				}
-
-				that.markImagePosition(click.x, click.y);
 			}
 		}
 	}
@@ -245,10 +231,10 @@ QuizUtil = {
 	clickIsRelevant: function(click, question) {
 		if(!question.type || question.type == 0 || question.type == 2) {
 			// standard type, user has to click an option
-			return click.type == "optionclick";
+			return click.hasOwnProperty("clickedoption");
 		} else if(question.type == 1) {
 			// user has to click a position in an image
-			return click.type == "imageclick";
+			return click.hasOwnProperty("x") && click.hasOwnProperty("y");
 		}
 		return false;
 	}


### PR DESCRIPTION
* When the answer is revealed, the answers of all participants are anonymized and then sent to the server and distributed.
    This enables clients to also display a vote count or where other users clicked in an image. It also unifies how revealing an answer works between the quizmaster and client pages.
* The `reveal` function in `static/shared.js` checks the type of the question to take appropriate action instead of taking all possible actions and filtering using `click.type`.
* The `clickIsRelevant` function has been changed to test if the respective properties of the click exist, not if `click.type` matches.
* As `click.type` is now no longer required, it has been removed.
* miscellaneous cleanup:
    * removed some trailing whitespace
    * changed leading spaces to tabs
    * remove erroneous `console.log`
